### PR TITLE
Add option to disable logging globally

### DIFF
--- a/MetroLog/Internal/Logger.cs
+++ b/MetroLog/Internal/Logger.cs
@@ -95,6 +95,8 @@ namespace MetroLog.Internal
         {
             try
             {
+                if (_configuration.IsEnabled == false) 
+                    return null;
                 var targets = _configuration.GetTargets(level);
                 if (!(targets.Any()))
                     return Task.FromResult(new LogWriteOperation[] { });

--- a/MetroLog/LoggingConfiguration.cs
+++ b/MetroLog/LoggingConfiguration.cs
@@ -9,6 +9,7 @@ namespace MetroLog
 {
     public class LoggingConfiguration
     {
+        public bool IsEnabled { get; set; }
         private readonly List<TargetBinding> _bindings;
         private readonly object _bindingsLock = new object();
 


### PR DESCRIPTION
Add IsEnabled flag to LoggingConfiguration.
Check IsEnabled flag in LogInternal() and return immediately if false.
This enables globally disabling logging, for example for Release configuration builds.
