### PR TITLE
Wpa 8.1 support

### DIFF
--- a/MetroLog.Shared.WinRT/WinRTFileTarget.cs
+++ b/MetroLog.Shared.WinRT/WinRTFileTarget.cs
@@ -61,7 +61,15 @@ namespace MetroLog
                     toDelete.Add(file);
             }
 
-            
+            //Queries are still not supported in Windows Phone 8.1. Ensure temp cleanup
+#if WINDOWS_PHONE_APP
+            var zipPattern = new Regex(@"^Log(.*).zip$");
+            foreach (var file in await ApplicationData.Current.TemporaryFolder.GetFilesAsync())
+            {
+                if (zipPattern.Match(file.Name).Success)
+                    toDelete.Add(file);
+            }
+#else
             var qo = new QueryOptions(CommonFileQuery.DefaultQuery, new [] {".zip"})
                 {
                     FolderDepth = FolderDepth.Shallow,
@@ -72,7 +80,7 @@ namespace MetroLog
 
             var oldLogs = await query.GetFilesAsync();
             toDelete.AddRange(oldLogs);
-
+#endif
             // walk...
             foreach (var file in toDelete)
             {


### PR DESCRIPTION
Fixes for unsupported queries, which came from WinRT implementation
Reference:
http://msdn.microsoft.com/en-us/library/windows/apps/windows.storage.search.queryoptions
