### PR TITLE
Fixed issue with JsonPostTarget not allowing custom auth headers

### DIFF
--- a/MetroLog.Shared/Targets/HttpClientEventHandler.cs
+++ b/MetroLog.Shared/Targets/HttpClientEventHandler.cs
@@ -15,6 +15,7 @@ namespace MetroLog.Targets
 
         public HttpClientEventArgs(HttpClient client)
         {
+            Client = client;
         }
 #endif
     }


### PR DESCRIPTION
Fixed issue with JsonPostTarget not passing its HttpClient to the OnBeforePost event, which was keeping clients from adding authentication or custom headers
