### PR TITLE
Add ConfigureAwait(false) to a couple of places to avoid potential deadlock

### DIFF
--- a/MetroLog.Shared.WinRT/FileTarget.cs
+++ b/MetroLog.Shared.WinRT/FileTarget.cs
@@ -56,7 +56,7 @@ namespace MetroLog
         protected sealed override async Task DoCleanup(Regex pattern, DateTime threshold)
         {
 
-            var toDelete = (await logFolder.GetFilesAsync())
+            var toDelete = (await logFolder.GetFilesAsync().AsTask().ConfigureAwait(false))
                             .Where(file => pattern.Match(file.Name).Success && file.DateCreated <= threshold)
                             .ToList();
 

--- a/MetroLog.Shared/Targets/FileTargetBase.cs
+++ b/MetroLog.Shared/Targets/FileTargetBase.cs
@@ -90,7 +90,7 @@ namespace MetroLog.Targets
                 // walk...
                 var regex = FileNamingParameters.GetRegex();
 
-                await DoCleanup(regex, threshold);
+                await DoCleanup(regex, threshold).ConfigureAwait(false);
             }
             finally
             {


### PR DESCRIPTION
Minimal, reproducible example:

```
// Configure the logging.
LogManagerFactory.DefaultConfiguration = new LoggingConfiguration();
StreamingFileTarget streamingFileTarget = new StreamingFileTarget();
LogManagerFactory.DefaultConfiguration.AddTarget(LogLevel.Trace, LogLevel.Fatal, streamingFileTarget);
LogManagerFactory.DefaultConfiguration.IsEnabled = true;

// Log a message.
ILogger log = LogManagerFactory.DefaultLogManager.GetLogger("logger");
log.Info("This is an info message");

// Get the compressed logs...this code deadlocks with the above log message.
Stream compressedLogs = null;
Task.Run(async () => compressedLogs = await LogManagerFactory.DefaultLogManager.GetCompressedLogs()).Wait();
```

I tried most (all?) of potential solutions at https://stackoverflow.com/questions/9343594/how-to-call-asynchronous-method-from-synchronous-method-in-c, but nothing worked for me. Except for adding ConfigureAwait(false) to a couple of places in this library....The changes in this pull request.

I think I'm trying to do basically the same thing as https://github.com/novotnyllc/MetroLog/issues/117.

I don't know if ConfigureAwait(false) should _also_ be added to additional places in this library. Also, I only tested this PR's changes on Windows, so there may be additional changes that are needed to get this to work on Android and iOS, and also maybe for other scenarios that we didn't test for on Windows.